### PR TITLE
missing transform callback for info-all parameter

### DIFF
--- a/dist/angular-bootstrap-duallistbox.js
+++ b/dist/angular-bootstrap-duallistbox.js
@@ -64,7 +64,8 @@ angular.module('frapontillo.bootstrap-duallistbox').directive('bsDuallistbox', [
             'nonSelectedListLabel': 'setNonSelectedListLabel',
             'infoAll': {
               changeFn: 'setInfoText',
-              defaultValue: 'Showing all {0}'
+	      defaultValue: 'Showing all {0}',
+	      transformFn: getBooleanValue	
             },
             'infoFiltered': {
               changeFn: 'setInfoTextFiltered',


### PR DESCRIPTION
We do not use false to disable info-all because it lacks the function to convert the value 'false' in its boolean equivalent.
