### PR TITLE
angular module Creation Syntax

### DIFF
--- a/src/directives/bsDuallistbox.js
+++ b/src/directives/bsDuallistbox.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('frapontillo.bootstrap-duallistbox')
+angular.module('frapontillo.bootstrap-duallistbox', [])
   .directive('bsDuallistbox', function ($compile, $timeout) {
     return {
       restrict: 'A',


### PR DESCRIPTION
Hi Friend, 
Your  :dizzy: angular-bootstrap-duallistbox :star:  it's very helpful :+1:  for me to implement bootstrap-duallistbox in my project. i found a small Syntax misplacing at angular module Creation at src/directives and i changed it, so please take my pull requsr:postbox: .

Thanks,
Manoj 