### PR TITLE
Update bsDuallistbox.js

### DIFF
--- a/src/directives/bsDuallistbox.js
+++ b/src/directives/bsDuallistbox.js
@@ -183,7 +183,7 @@ angular.module('frapontillo.bootstrap-duallistbox')
             selectedListLabel: defaults.selectedListLabel,
             nonSelectedListLabel: defaults.nonSelectedListLabel,
             helperSelectNamePostfix: defaults.postfix,
-            selectOrMinimalHeight: defaults.selectMinHeight,
+            selectorMinimalHeight: defaults.selectMinHeight,
             showFilterInputs: defaults.filter,
             nonSelectedFilter: '',
             selectedFilter: '',

--- a/src/directives/bsDuallistbox.js
+++ b/src/directives/bsDuallistbox.js
@@ -20,7 +20,7 @@ angular.module('frapontillo.bootstrap-duallistbox')
         var attributes = {
           'bootstrap2': {changeFn: 'setBootstrap2Compatible', transformFn: getBooleanValue},
           'postfix': 'setHelperSelectNamePostfix',
-          'selectMinHeight': {changeFn: 'setSelectOrMinimalHeight', defaultValue: 100},
+          'selectMinHeight': {changeFn: 'setSelectorMinimalHeight', defaultValue: 100},
 
           'filter':  {changeFn: 'setShowFilterInputs', defaultValue: true, transformFn: getBooleanValue},
           'filterClear': {changeFn: 'setFilterTextClear', defaultValue: 'show all'},


### PR DESCRIPTION
fix for setting minimum height of listbox.
Setting minimum height was not working due to a simple typo in the base library settings.
